### PR TITLE
Use "✔" instead of "*" for the selected theme

### DIFF
--- a/common/header.html
+++ b/common/header.html
@@ -46,7 +46,7 @@ api.createWidget("theme-selector", {
             return themes.map(theme => {
                 let name = [theme.name];
                 if (theme.id === currentThemeId) {
-                    name.push('\xa0' + "*");
+                    name.push('\xa0' + "✔");
                 }
                 return h('li', {attributes: {"data-name": theme.name}}, h('a.widget-link', {attributes: {"data-id": theme.id}}, name));
             });


### PR DESCRIPTION
It's only a design proposition, you can decline 

![Hamburger theme selector](https://user-images.githubusercontent.com/12373169/132507136-08d05d67-8087-462a-8e3f-304df9214dc8.png)